### PR TITLE
Styling taxonomy pages

### DIFF
--- a/js/packages/styles/css/main.css
+++ b/js/packages/styles/css/main.css
@@ -101,8 +101,20 @@
 @tailwind components;
 @tailwind utilities;
 
+/* Other application stylesheets */
+
+@import url('./forms.css');
+@import url('./taxonomy.css');
+
 #block-idcui-page-title h1 {
   @apply text-3xl;
+}
+
+a {
+  @apply text-blue-heritage;
+}
+nav a {
+  @apply text-white;
 }
 
 .button {
@@ -129,4 +141,11 @@
   @apply m-8 p-4 shadow-md bg-white;
 }
 
-@import url('./forms.css');
+/* Admin quick-actions */
+.block-local-tasks-block ul {
+  @apply border-b-2;
+}
+
+.block-local-tasks-block li {
+  @apply inline-block mx-4 my-2;
+}

--- a/js/packages/styles/css/main.css
+++ b/js/packages/styles/css/main.css
@@ -140,12 +140,3 @@ nav a {
 .card {
   @apply m-8 p-4 shadow-md bg-white;
 }
-
-/* Admin quick-actions */
-.block-local-tasks-block ul {
-  @apply border-b-2;
-}
-
-.block-local-tasks-block li {
-  @apply inline-block mx-4 my-2;
-}

--- a/js/packages/styles/css/taxonomy.css
+++ b/js/packages/styles/css/taxonomy.css
@@ -4,3 +4,7 @@
 .taxonomy-term p {
   @apply my-4;
 }
+
+.taxonomy-item .views-row article {
+  @apply float-left mr-4;
+}

--- a/js/packages/styles/css/taxonomy.css
+++ b/js/packages/styles/css/taxonomy.css
@@ -1,12 +1,6 @@
-/* CSS for taxonomy pages */
+/*
+ * CSS for taxonomy pages
+ */
 .taxonomy-term p {
   @apply my-4;
-}
-
-.taxonomy-item {
-  @apply my-8;
-}
-
-.taxonomy-item h2 {
-  @apply text-xl;
 }

--- a/js/packages/styles/css/taxonomy.css
+++ b/js/packages/styles/css/taxonomy.css
@@ -1,0 +1,12 @@
+/* CSS for taxonomy pages */
+.taxonomy-term p {
+  @apply my-4;
+}
+
+.taxonomy-item {
+  @apply my-8;
+}
+
+.taxonomy-item h2 {
+  @apply text-xl;
+}

--- a/templates/content/node--islandora-object--teaser.html.twig
+++ b/templates/content/node--islandora-object--teaser.html.twig
@@ -1,0 +1,104 @@
+{#
+/**
+ * @file
+ * Theme override to display a node.
+ *
+ * Available variables:
+ * - node: The node entity with limited access to object properties and methods.
+ *   Only method names starting with "get", "has", or "is" and a few common
+ *   methods such as "id", "label", and "bundle" are available. For example:
+ *   - node.getCreatedTime() will return the node creation timestamp.
+ *   - node.hasField('field_example') returns TRUE if the node bundle includes
+ *     field_example. (This does not indicate the presence of a value in this
+ *     field.)
+ *   - node.isPublished() will return whether the node is published or not.
+ *   Calling other methods, such as node.delete(), will result in an exception.
+ *   See \Drupal\node\Entity\Node for a full list of public properties and
+ *   methods for the node object.
+ * - label: The title of the node.
+ * - content: All node items. Use {{ content }} to print them all,
+ *   or print a subset such as {{ content.field_example }}. Use
+ *   {{ content|without('field_example') }} to temporarily suppress the printing
+ *   of a given child element.
+ * - author_picture: The node author user entity, rendered using the "compact"
+ *   view mode.
+ * - metadata: Metadata for this node.
+ * - date: Themed creation date field.
+ * - author_name: Themed author name field.
+ * - url: Direct URL of the current node.
+ * - display_submitted: Whether submission information should be displayed.
+ * - attributes: HTML attributes for the containing element.
+ *   The attributes.class element may contain one or more of the following
+ *   classes:
+ *   - node: The current template type (also known as a "theming hook").
+ *   - node--type-[type]: The current node type. For example, if the node is an
+ *     "Article" it would result in "node--type-article". Note that the machine
+ *     name will often be in a short form of the human readable label.
+ *   - node--view-mode-[view_mode]: The View Mode of the node; for example, a
+ *     teaser would result in: "node--view-mode-teaser", and
+ *     full: "node--view-mode-full".
+ *   The following are controlled through the node publishing options.
+ *   - node--promoted: Appears on nodes promoted to the front page.
+ *   - node--sticky: Appears on nodes ordered above other non-sticky nodes in
+ *     teaser listings.
+ *   - node--unpublished: Appears on unpublished nodes visible only to site
+ *     admins.
+ * - title_attributes: Same as attributes, except applied to the main title
+ *   tag that appears in the template.
+ * - content_attributes: Same as attributes, except applied to the main
+ *   content tag that appears in the template.
+ * - author_attributes: Same as attributes, except applied to the author of
+ *   the node tag that appears in the template.
+ * - title_prefix: Additional output populated by modules, intended to be
+ *   displayed in front of the main title tag that appears in the template.
+ * - title_suffix: Additional output populated by modules, intended to be
+ *   displayed after the main title tag that appears in the template.
+ * - view_mode: View mode; for example, "teaser" or "full".
+ * - teaser: Flag for the teaser state. Will be true if view_mode is 'teaser'.
+ * - page: Flag for the full page state. Will be true if view_mode is 'full'.
+ * - readmore: Flag for more state. Will be true if the teaser content of the
+ *   node cannot hold the main body content.
+ * - logged_in: Flag for authenticated user status. Will be true when the
+ *   current user is a logged-in member.
+ * - is_admin: Flag for admin user status. Will be true when the current user
+ *   is an administrator.
+ *
+ * @see template_preprocess_node()
+ *
+ * @todo Remove the id attribute (or make it a class), because if that gets
+ *   rendered twice on a page this is invalid CSS for example: two lists
+ *   in different view modes.
+ */
+#}
+
+{#
+/**
+ * Template override for Islandora Object content type "Teaser" display type
+ */
+#}
+
+<article{{ attributes.addClass("taxonomy-item") }}>
+
+  {{ title_prefix }}
+  {% if not page %}
+    <h2{{ title_attributes }}>
+      <a href="{{ url }}" rel="bookmark">{{ label }}</a>
+    </h2>
+  {% endif %}
+  {{ title_suffix }}
+
+  {% if display_submitted %}
+    <footer>
+      {{ author_picture }}
+      <div{{ author_attributes.addClass("italic") }}>
+        {% trans %}Submitted by {{ author_name }} on {{ date }}{% endtrans %}
+        {{ metadata }}
+      </div>
+    </footer>
+  {% endif %}
+
+  <div{{ content_attributes }}>
+    {{ content }}
+  </div>
+
+</article>

--- a/templates/content/node--islandora-object--teaser.html.twig
+++ b/templates/content/node--islandora-object--teaser.html.twig
@@ -77,11 +77,11 @@
  */
 #}
 
-<article{{ attributes.addClass("taxonomy-item") }}>
+<article{{ attributes.addClass([ "taxonomy-item", "my-8" ]) }}>
 
   {{ title_prefix }}
   {% if not page %}
-    <h2{{ title_attributes }}>
+    <h2{{ title_attributes.addClass("text-xl") }}>
       <a href="{{ url }}" rel="bookmark">{{ label }}</a>
     </h2>
   {% endif %}

--- a/templates/content/taxonomy-term.html.twig
+++ b/templates/content/taxonomy-term.html.twig
@@ -1,0 +1,41 @@
+{#
+/**
+ * @file
+ * Theme override to display a taxonomy term.
+ *
+ * Available variables:
+ * - url: URL of the current term.
+ * - name: (optional) Name of the current term.
+ * - content: Items for the content of the term (fields and description).
+ *   Use 'content' to print them all, or print a subset such as
+ *   'content.description'. Use the following code to exclude the
+ *   printing of a given child element:
+ *   @code
+ *   {{ content|without('description') }}
+ *   @endcode
+ * - attributes: HTML attributes for the wrapper.
+ * - page: Flag for the full page state.
+ * - term: The taxonomy term entity, including:
+ *   - id: The ID of the taxonomy term.
+ *   - bundle: Machine name of the current vocabulary.
+ * - view_mode: View mode, e.g. 'full', 'teaser', etc.
+ *
+ * @see template_preprocess_taxonomy_term()
+ */
+#}
+{%
+  set classes = [
+    'taxonomy-term',
+    'vocabulary-' ~ term.bundle|clean_class,
+  ]
+%}
+<div{{ attributes.setAttribute('id', 'taxonomy-term-' ~ term.id).addClass(classes) }}>
+  {{ title_prefix }}
+  {% if name and not page %}
+    <h2><a href="{{ url }}">{{ name }}</a></h2>
+  {% endif %}
+  {{ title_suffix }}
+  <div class="content">
+    {{ content }}
+  </div>
+</div>

--- a/templates/content/taxonomy-term.html.twig
+++ b/templates/content/taxonomy-term.html.twig
@@ -35,7 +35,7 @@
     <h2><a href="{{ url }}">{{ name }}</a></h2>
   {% endif %}
   {{ title_suffix }}
-  <div class="content">
+  <div class="content py-4 border-b">
     {{ content }}
   </div>
 </div>

--- a/templates/field/field--taxonomy-term--field-authority-link.html.twig
+++ b/templates/field/field--taxonomy-term--field-authority-link.html.twig
@@ -1,0 +1,50 @@
+{#
+/**
+ * @file
+ * Theme override for a field.
+ *
+ * To override output, copy the "field.html.twig" from the templates directory
+ * to your theme's directory and customize it, just like customizing other
+ * Drupal templates such as page.html.twig or node.html.twig.
+ *
+ * Instead of overriding the theming for all fields, you can also just override
+ * theming for a subset of fields using
+ * @link themeable Theme hook suggestions. @endlink For example,
+ * here are some theme hook suggestions that can be used for a field_foo field
+ * on an article node type:
+ * - field--node--field-foo--article.html.twig
+ * - field--node--field-foo.html.twig
+ * - field--node--article.html.twig
+ * - field--field-foo.html.twig
+ * - field--text-with-summary.html.twig
+ * - field.html.twig
+ *
+ * Available variables:
+ * - attributes: HTML attributes for the containing element.
+ * - label_hidden: Whether to show the field label or not.
+ * - title_attributes: HTML attributes for the title.
+ * - label: The label for the field.
+ * - multiple: TRUE if a field can contain multiple items.
+ * - items: List of all the field items. Each item contains:
+ *   - attributes: List of HTML attributes for each item.
+ *   - content: The field item's content.
+ * - entity_type: The entity type to which the field belongs.
+ * - field_name: The name of the field.
+ * - field_type: The type of the field.
+ * - label_display: The display settings for the label.
+ *
+ * @see template_preprocess_field()
+ */
+#}
+
+{% set wrapper_classes = [ 'my-4' ] %}
+{% set title_classes = [ 'text-lg', 'font-bold' ] %}
+
+<div {{ attributes.addClass(wrapper_classes) }}>
+  <h2 {{ title_attributes.addClass(title_classes) }}>
+    {{ label }}
+  </h2>
+  {% for item in items %}
+    {{ item.content }}
+  {% endfor %}
+</div>

--- a/templates/navigation/menu-local-task.html.twig
+++ b/templates/navigation/menu-local-task.html.twig
@@ -1,0 +1,20 @@
+{#
+/**
+ * @file
+ * Theme override for a local task link.
+ *
+ * Available variables:
+ * - attributes: HTML attributes for the wrapper element.
+ * - is_active: Whether the task item is an active tab.
+ * - link: A rendered link element.
+ *
+ * Note: This template renders the content for each task item in
+ * menu-local-tasks.html.twig.
+ *
+ * @see template_preprocess_menu_local_task()
+ */
+#}
+
+{% set task_classes = [ "inline-block", "px-6", "py-2" ] %}
+
+<li{{ attributes.addClass(task_classes) }}>{{ link }}</li>

--- a/templates/navigation/menu-local-tasks.html.twig
+++ b/templates/navigation/menu-local-tasks.html.twig
@@ -1,0 +1,21 @@
+{#
+/**
+ * @file
+ * Theme override to display primary and secondary local tasks.
+ *
+ * Available variables:
+ * - primary: HTML list items representing primary tasks.
+ * - secondary: HTML list items representing primary tasks.
+ *
+ * Each item in these variables (primary and secondary) can be individually
+ * themed in menu-local-task.html.twig.
+ */
+#}
+{% if primary %}
+  <h2 class="visually-hidden">{{ 'Primary tabs'|t }}</h2>
+  <ul class="border-b-2 divide-x py-2">{{ primary }}</ul>
+{% endif %}
+{% if secondary %}
+  <h2 class="visually-hidden">{{ 'Secondary tabs'|t }}</h2>
+  <ul>{{ secondary }}</ul>
+{% endif %}

--- a/templates/pages/page--taxonomy--term.html.twig
+++ b/templates/pages/page--taxonomy--term.html.twig
@@ -1,0 +1,12 @@
+<main role="main">
+  <a id="main-content" tabindex="-1"></a>
+  <div class="layout-content p-12 pt-6 border-t">
+    <div class="">
+      {{ page.content.idcui_page_title }}
+    </div>
+
+    <div class="">
+      {{ page.content.idcui_content }}
+    </div>
+  </div>
+</main>


### PR DESCRIPTION
https://github.com/jhu-idc/iDC-general/issues/116

Adds some styling for the taxonomy pages in Drupal. Taxonomy terms are provided by the system and are publicly viewable. Each page will contain a description, where possible, as well as a list of items that use the specific term.

The templates were copied from Drupal's `stable` theme with our own style classes added where needed.

To test, you'll need one or more Repository Item objects created in Drupal that use one of the defined taxonomies. For example, I created some dummy items that used the `In Copyright` term in the `Copyright and Use` taxonomy. This resulted in a page that looked like:

![image](https://user-images.githubusercontent.com/5167587/104358754-e1a29900-54dc-11eb-84e6-da25f8e7ae55.png)


TODO:

* [ ] ~~wrap part of the content in a card-like style to make it look closer to other public pages.~~
* [x] add some thumbnails to display in the items list