### PR TITLE
Islandora Object page fixes

### DIFF
--- a/templates/pages/page--node--islandora-object.html.twig
+++ b/templates/pages/page--node--islandora-object.html.twig
@@ -147,31 +147,32 @@
             <div class="child-wrapper border-b last:border-b-0 space-y-2">
               <button class="accordian-btn w-full py-4 bg-blue-spirit text-black" data-action="click->media-downloads-modal#toggleChildMedia"><h1>{{ child.title }}</h1></button>
               <div class="child-node overflow-auto transition-all ease-in-out duration-300 max-h-0 pt-2">
-              <a class="mt-4" href={{"https://islandora-idc.traefik.me/media_download_all/node/" ~ child.id}} download={{'all_media_' ~ child.id ~ '.zip'}}>Download All Available Media for {{ child.title }}</a>
-              {% for media in child.media_links %}
-                <div class="flex flex-col md:flex-row border-b py-4 last:border-b-0">
-                  <div class="flex flex-col md:flex-row">
-                    <div class="flex">
-                      <span class="line-clamp-1">{{media.file_name}}</span><span class="hidden md:flex">&nbsp;&nbsp;|&nbsp;&nbsp;</span>
+                <a class="mt-4" href={{"https://islandora-idc.traefik.me/media_download_all/node/" ~ child.id}} download={{'all_media_' ~ child.id ~ '.zip'}}>Download All Available Media for {{ child.title }}</a>
+                {% for media in child.media_links %}
+                  <div class="flex flex-col md:flex-row border-b py-4 last:border-b-0">
+                    <div class="flex flex-col md:flex-row">
+                      <div class="flex">
+                        <span class="line-clamp-1">{{media.file_name}}</span><span class="hidden md:flex">&nbsp;&nbsp;|&nbsp;&nbsp;</span>
+                      </div>
+                      <div class="flex text-black">
+                        <span class="text-gray-500 line-clamp-1">{{media.media_type}}</span><span class="hidden md:flex">&nbsp;&nbsp;|&nbsp;&nbsp;</span>
+                      </div>
+                      <div class="flex text-gray-500">
+                        <span class="line-clamp-1">{{media.media_use}}</span><span class="hidden md:flex text-black">&nbsp;&nbsp;|&nbsp;&nbsp;</span>
+                      </div>
                     </div>
-                    <div class="flex text-black">
-                      <span class="text-gray-500 line-clamp-1">{{media.media_type}}</span><span class="hidden md:flex">&nbsp;&nbsp;|&nbsp;&nbsp;</span>
-                    </div>
-                    <div class="flex text-gray-500">
-                      <span class="line-clamp-1">{{media.media_use}}</span><span class="hidden md:flex text-black">&nbsp;&nbsp;|&nbsp;&nbsp;</span>
-                    </div>
+                    {% if media.url %}
+                      <div>
+                        <a href={{media.url}} download={{media.file_name}}>Download Link</a>
+                      </div>
+                    {% else %}
+                      <div class="text-gray-600 italic line-clamp-1">
+                        Contact the collection admin for access
+                      </div>
+                    {% endif %}
                   </div>
-                  {% if media.url %}
-                    <div>
-                      <a href={{media.url}} download={{media.file_name}}>Download Link</a>
-                    </div>
-                  {% else %}
-                    <div class="text-gray-600 italic line-clamp-1">
-                      Contact the collection admin for access
-                    </div>
-                  {% endif %}
-                </div>
-              {% endfor %}
+                {% endfor %}
+              </div>
             </div>
           {% endfor %}
         {% endif %}

--- a/templates/pages/page--node--islandora-object.html.twig
+++ b/templates/pages/page--node--islandora-object.html.twig
@@ -146,7 +146,7 @@
           {% for child in children_media_links %}
             <div class="child-wrapper border-b last:border-b-0 space-y-2">
               <button class="accordian-btn w-full py-4 bg-blue-spirit text-black" data-action="click->media-downloads-modal#toggleChildMedia"><h1>{{ child.title }}</h1></button>
-              <div class="child-node overflow-auto transition-all ease-in-out duration-300 max-h-0 pt-2">
+              <div class="child-node overflow-auto transition-all ease-in-out duration-300 pt-2" style="max-height: 0px">
                 <a class="mt-4" href={{"https://islandora-idc.traefik.me/media_download_all/node/" ~ child.id}} download={{'all_media_' ~ child.id ~ '.zip'}}>Download All Available Media for {{ child.title }}</a>
                 {% for media in child.media_links %}
                   <div class="flex flex-col md:flex-row border-b py-4 last:border-b-0">


### PR DESCRIPTION
Related: https://github.com/jhu-idc/iDC-general/issues/437

Merging this will still require updating the theme dependency in `idc-isle-dc`

### Issue(s)

Various rendering issues on the Islandora Object details pages, only apparent on "Paged Content" nodes:

* Footer did not appear
* Citations and Media Download modals acted very strange
  * Media Download buttoner would sometimes toggle the media downloads modal, sometimes toggle the citations modal
  * Citations button seemingly did nothing
* The child media toggles had to be double clicked to reveal the child media download info. After the initial double click, it could be single clicked to toggle correctly

### Changes:

* Close an unclosed `<div>`
  * The `child-node` within the `children_media_links` loop was not closed, causing odd rendering issues
* Default child media accordion to have `max-height: 0px` style so a user no longer has to double click the toggle to reveal the panel
  * Force the `child-node` element to have `style="max-height: 0px"` in order to better mesh with the toggle logic in the Stimulus controller
  * Remove the `max-h-0` Tailwind class, as the above style does the same job