### PR TITLE
Update authority links to appear on newlines

### DIFF
--- a/templates/field/field--taxonomy-term--field-authority-link.html.twig
+++ b/templates/field/field--taxonomy-term--field-authority-link.html.twig
@@ -45,6 +45,6 @@
     {{ label }}
   </h2>
   {% for item in items %}
-    {{ item.content }}
+    <p>{{ item.content }</p>
   {% endfor %}
 </div>


### PR DESCRIPTION
Improve readability and accessibility by using p tags to separate each authority source link.