### PR TITLE
add link to bottom of the page for json-ld format

### DIFF
--- a/templates/content/taxonomy-term.html.twig
+++ b/templates/content/taxonomy-term.html.twig
@@ -37,6 +37,8 @@
   {{ title_suffix }}
   <div class="content">
     {{ content }}
-    <a href="{{[url, "?_format=json"]|safeJoin}}">View metadata in JSON format</a>
+    {% if url %}
+      <a href="{{[url, "?_format=json"]|safeJoin}}">View metadata in JSON format</a>
+    {% endif %}
   </div>
 </div>

--- a/templates/content/taxonomy-term.html.twig
+++ b/templates/content/taxonomy-term.html.twig
@@ -37,5 +37,6 @@
   {{ title_suffix }}
   <div class="content">
     {{ content }}
+    <a href="{{[url, "?_format=json"]|safeJoin}}">View metadata in JSON format</a>
   </div>
 </div>

--- a/templates/content/taxonomy-term.html.twig
+++ b/templates/content/taxonomy-term.html.twig
@@ -37,8 +37,5 @@
   {{ title_suffix }}
   <div class="content">
     {{ content }}
-    {% if url %}
-      <a href="{{[url, "?_format=json"]|safeJoin}}">View metadata in JSON format</a>
-    {% endif %}
   </div>
 </div>

--- a/templates/pages/page--node--islandora-object.html.twig
+++ b/templates/pages/page--node--islandora-object.html.twig
@@ -71,6 +71,8 @@
         </div>
         {{ page.content.idcui_content }}
         {{ page.content.system_main }}
+        <hr style="margin-bottom:10px" />
+        <a href="{{[url('<current>'), "?_format=json"]|safe_join}}">View metadata in JSON format</a>
       </div>
     </div>
   </div>


### PR DESCRIPTION
Added a link to the bottom of the taxonomy term page that will take the user to the json format of the term.